### PR TITLE
Fix server URL handling for clients and server

### DIFF
--- a/client/sse/client.py
+++ b/client/sse/client.py
@@ -23,7 +23,7 @@ class MCPSSEClient:
     async def get_resource(self, resource_name):
         """Get a resource from the server"""
         logger.info(f"Requesting resource: {resource_name}")
-        result = await self.client.get(f"http://localhost:8000/{resource_name}")
+        result = await self.client.get(f"{self.server_url.rstrip('/')}/{resource_name}")
         logger.info(f"Received {resource_name}: {result}")
         return result
     
@@ -32,9 +32,9 @@ class MCPSSEClient:
         logger.info(f"Updating resource {resource_name} with value: {value}")
         # For PUT requests to counter, use the special update endpoint
         if resource_name == "counter":
-            result = await self.client.put(f"http://localhost:8000/counter/update", value)
+            result = await self.client.put(f"{self.server_url.rstrip('/')}/counter/update", value)
         else:
-            result = await self.client.put(f"http://localhost:8000/{resource_name}", value)
+            result = await self.client.put(f"{self.server_url.rstrip('/')}/{resource_name}", value)
         logger.info(f"Resource {resource_name} updated to: {result}")
         return result
     

--- a/server/server.py
+++ b/server/server.py
@@ -57,14 +57,16 @@ class MCPDemoServer:
             logger.info(f"Counter updated to {sample_resources['counter']}")
             return sample_resources["counter"]
         
+        base_url = f"http://{self.host}:{self.port}"
+
         # Add resources using add_resource_fn method with complete URLs
-        self.server.add_resource_fn(get_greeting, uri="http://localhost:8000/greeting")
-        self.server.add_resource_fn(get_status, uri="http://localhost:8000/status")
-        self.server.add_resource_fn(get_info, uri="http://localhost:8000/info")
-        self.server.add_resource_fn(get_counter, uri="http://localhost:8000/counter")
+        self.server.add_resource_fn(get_greeting, uri=f"{base_url}/greeting")
+        self.server.add_resource_fn(get_status, uri=f"{base_url}/status")
+        self.server.add_resource_fn(get_info, uri=f"{base_url}/info")
+        self.server.add_resource_fn(get_counter, uri=f"{base_url}/counter")
         
         # Add resource with PUT method - need to use a different URI to avoid conflict
-        self.server.add_resource_fn(update_counter, uri="http://localhost:8000/counter/update")
+        self.server.add_resource_fn(update_counter, uri=f"{base_url}/counter/update")
         
     # Resource methods are now defined inside setup_resources using decorators
     


### PR DESCRIPTION
## Summary
- fix SSE client to respect user-provided server URL
- build server resource URLs dynamically from `host` and `port`

## Testing
- `python -m py_compile client/sse/client.py server/server.py client/stdio/client.py client/client.py`

------
https://chatgpt.com/codex/tasks/task_e_6880c17c29648328b0fd255b189f1207