### PR TITLE
Add SSE client tests

### DIFF
--- a/pytest_asyncio.py
+++ b/pytest_asyncio.py
@@ -1,0 +1,15 @@
+import asyncio
+import pytest
+
+def pytest_configure(config):
+    config.addinivalue_line('markers', 'asyncio: mark test to run with asyncio')
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_pyfunc_call(pyfuncitem):
+    if 'asyncio' in pyfuncitem.keywords:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(pyfuncitem.obj(**pyfuncitem.funcargs))
+        finally:
+            loop.close()
+        return True

--- a/tests/test_sse_client.py
+++ b/tests/test_sse_client.py
@@ -1,0 +1,64 @@
+pytest_plugins = ['pytest_asyncio']
+
+import types
+import sys
+from unittest.mock import AsyncMock, patch
+
+# create dummy fastmcp modules if not installed
+fastmcp_client = types.ModuleType('fastmcp.client')
+fastmcp_transports = types.ModuleType('fastmcp.client.transports')
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def get(self, *a, **k):
+        pass
+
+    async def put(self, *a, **k):
+        pass
+
+class DummyTransport:
+    def __init__(self, url):
+        self.url = url
+
+fastmcp_client.Client = DummyClient
+fastmcp_transports.SSETransport = DummyTransport
+fastmcp_client.transports = fastmcp_transports
+
+fastmcp = types.ModuleType('fastmcp')
+fastmcp.client = fastmcp_client
+sys.modules.setdefault('fastmcp', fastmcp)
+sys.modules.setdefault('fastmcp.client', fastmcp_client)
+sys.modules.setdefault('fastmcp.client.transports', fastmcp_transports)
+
+from client.sse.client import MCPSSEClient
+
+
+import pytest
+
+@pytest.mark.asyncio
+async def test_get_resource_url_prefix():
+    with patch('client.sse.client.Client.get', new_callable=AsyncMock) as mock_get:
+        c = MCPSSEClient('http://example.com')
+        await c.get_resource('hello')
+        mock_get.assert_awaited_once()
+        assert mock_get.call_args[0][0].startswith('http://example.com')
+
+
+@pytest.mark.asyncio
+async def test_update_resource_url_prefix_counter():
+    with patch('client.sse.client.Client.put', new_callable=AsyncMock) as mock_put:
+        c = MCPSSEClient('http://example.com')
+        await c.update_resource('counter', 5)
+        mock_put.assert_awaited_once()
+        assert mock_put.call_args[0][0].startswith('http://example.com')
+
+
+@pytest.mark.asyncio
+async def test_update_resource_url_prefix_general():
+    with patch('client.sse.client.Client.put', new_callable=AsyncMock) as mock_put:
+        c = MCPSSEClient('http://example.com')
+        await c.update_resource('foo', 'bar')
+        mock_put.assert_awaited_once()
+        assert mock_put.call_args[0][0].startswith('http://example.com')


### PR DESCRIPTION
## Summary
- add minimal pytest_asyncio plugin so async tests run without external deps
- add tests for MCPSSEClient URL formation

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c6194f708328a753cabb1f880596